### PR TITLE
Add Sentinel Scan CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A curated list of AI security resources inspired by [awesome-adversarial-machine
 |![][code]|[dstack - Confidential AI framework for secure ML/LLM deployment with hardware-enforced isolation and data privacy](https://github.com/Dstack-TEE/dstack)|
 |![][code]|[ClawMoat - Open-source runtime security scanner for AI agents. Detects prompt injection, jailbreak, PII leakage, memory poisoning, and tool misuse](https://github.com/darfaz/clawmoat)|
 |![][code]|[SkillFortify - Formal analysis and supply chain security for agentic AI skills. Sound static analysis, SAT-based dependency resolution, trust scoring, CycloneDX ASBOM. 5 theorems, F1=96.95%, 0% FP rate](https://github.com/varun369/skillfortify)|
+|![][code]|[Sentinel Scan CLI - Free CLI that runs a 15-attack prompt-injection and jailbreak suite against your own LLM endpoint, with real findings included](https://github.com/Ventrova/sentinel-scan-cli)|
 
 ## [▲](#keywords) Links
 |Type|Title|


### PR DESCRIPTION
Adds Sentinel Scan CLI, a free CLI that runs a 15-attack prompt-injection and jailbreak test suite against your own LLM endpoint, with a scored report and real findings included. Disclosure: this is our own tool (Ventrova).